### PR TITLE
Enable attachment pages in WP 6.4+

### DIFF
--- a/community-gallery-tags.php
+++ b/community-gallery-tags.php
@@ -583,3 +583,8 @@ add_action(
 		wp_safe_redirect( admin_url( 'upload.php?page=cgt-management' ) );
 	}
 );
+
+/**
+ * Enables attachment pages for WP 6.4+.
+ */
+add_action( 'pre_option_wp_attachment_pages_enabled', '__return_true' );


### PR DESCRIPTION
### Changes proposed in this PR

- Enable attachment pages in WP 6.4+
- https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/